### PR TITLE
웹 풀사이클 리액트 강의 - 컴포넌트 및 상태 정보 관리 프로젝트(7)

### DIFF
--- a/bookstore/frontend/.eslintrc.cjs
+++ b/bookstore/frontend/.eslintrc.cjs
@@ -2,17 +2,17 @@ module.exports = {
   root: true,
   env: { browser: true, es2020: true },
   extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:react-hooks/recommended',
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh'],
+  ignorePatterns: ["dist", ".eslintrc.cjs", "vite.config.ts"],
+  parser: "@typescript-eslint/parser",
+  plugins: ["react-refresh"],
   rules: {
-    'react-refresh/only-export-components': [
-      'warn',
+    "react-refresh/only-export-components": [
+      "warn",
       { allowConstantExport: true },
     ],
   },
-}
+};

--- a/bookstore/frontend/package-lock.json
+++ b/bookstore/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.25.1",
         "sanitize.css": "^13.0.0",
         "styled-components": "^6.1.12",
+        "vite-tsconfig-paths": "^4.3.2",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
@@ -1495,7 +1496,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/history": {
       "version": "4.7.11",
@@ -2252,7 +2253,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2356,7 +2356,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2954,6 +2954,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3442,8 +3447,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -3674,7 +3678,7 @@
       "version": "8.4.39",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
       "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3942,7 +3946,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
       "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -4365,6 +4369,25 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.1.tgz",
+      "integrity": "sha512-00eoI6WY57SvZEVjm13stEVE90VkEdJAFGgpFLTsZbJyW/LwFQ7uQxJHWpZ2hzSWgCPKc9AnBnNP+0X7o3hAmQ==",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -4398,7 +4421,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4477,7 +4500,7 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.4.tgz",
       "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.39",
@@ -4548,6 +4571,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {

--- a/bookstore/frontend/package-lock.json
+++ b/bookstore/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.51.15",
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.7.2",
         "dayjs": "^1.11.12",
@@ -22,6 +23,7 @@
         "zustand": "^4.5.4"
       },
       "devDependencies": {
+        "@tanstack/eslint-plugin-query": "^5.51.15",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^18.3.3",
@@ -1332,6 +1334,143 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.51.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.51.15.tgz",
+      "integrity": "sha512-btX03EOGvNxTGJDqHMmQwfSt/hp93Z8I4FNBijoyEdDnjGi4jVjpGP7nEi9LaMnHFsylucptVGb6GQngWs07bA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "8.0.0-alpha.30"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8 || ^9"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0-alpha.30.tgz",
+      "integrity": "sha512-FGW/iPWGyPFamAVZ60oCAthMqQrqafUGebF8UKuq/ha+e9SVG6YhJoRzurlQXOVf8dHfOhJ0ADMXyFnMc53clg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0-alpha.30",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.30"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/types": {
+      "version": "8.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.30.tgz",
+      "integrity": "sha512-4WzLlw27SO9pK9UFj/Hu7WGo8WveT0SEiIpFVsV2WwtQmLps6kouwtVCB8GJPZKJyurhZhcqCoQVQFmpv441Vg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.30.tgz",
+      "integrity": "sha512-WSXbc9ZcXI+7yC+6q95u77i8FXz6HOLsw3ST+vMUlFy1lFbXyFL/3e6HDKQCm2Clt0krnoCPiTGvIn+GkYPn4Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0-alpha.30",
+        "@typescript-eslint/visitor-keys": "8.0.0-alpha.30",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/utils": {
+      "version": "8.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0-alpha.30.tgz",
+      "integrity": "sha512-rfhqfLqFyXhHNDwMnHiVGxl/Z2q/3guQ1jLlGQ0hi9Rb7inmwz42crM+NnLPR+2vEnwyw1P/g7fnQgQ3qvFx4g==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.0.0-alpha.30",
+        "@typescript-eslint/types": "8.0.0-alpha.30",
+        "@typescript-eslint/typescript-estree": "8.0.0-alpha.30"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0-alpha.30.tgz",
+      "integrity": "sha512-XZuNurZxBqmr6ZIRIwWFq7j5RZd6ZlkId/HZEWyfciK+CWoyOxSF9Pv2VXH9Rlu2ZG2PfbhLz2Veszl4Pfn7yA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0-alpha.30",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.51.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.51.15.tgz",
+      "integrity": "sha512-xyobHDJ0yhPE3+UkSQ2/4X1fLSg7ICJI5J1JyU9yf7F3deQfEwSImCDrB1WSRrauJkMtXW7YIEcC0oA6ZZWt5A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.51.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.15.tgz",
+      "integrity": "sha512-UgFg23SrdIYrmfTSxAUn9g+J64VQy11pb9/EefoY/u2+zWuNMeqEOnvpJhf52XQy0yztQoyM9p6x8PFyTNaxXg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.51.15"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.3.2",

--- a/bookstore/frontend/package.json
+++ b/bookstore/frontend/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.51.15",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.7.2",
     "dayjs": "^1.11.12",
@@ -27,6 +28,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@tanstack/eslint-plugin-query": "^5.51.15",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.3.3",

--- a/bookstore/frontend/package.json
+++ b/bookstore/frontend/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.25.1",
     "sanitize.css": "^13.0.0",
     "styled-components": "^6.1.12",
+    "vite-tsconfig-paths": "^4.3.2",
     "zustand": "^4.5.4"
   },
   "devDependencies": {

--- a/bookstore/frontend/src/App.tsx
+++ b/bookstore/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import BookDetail from "./pages/BookDetail";
 import Cart from "./pages/Cart";
 import Order from "./pages/Order";
 import OrderList from "./pages/OrderList";
+import { queryClient } from "./api/queryClient";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 const routeList = [
   {
@@ -63,9 +65,11 @@ const router = createBrowserRouter(
 
 const App = () => {
   return (
-    <BookStoreThemeProvider>
-      <RouterProvider router={router} />
-    </BookStoreThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <BookStoreThemeProvider>
+        <RouterProvider router={router} />
+      </BookStoreThemeProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/bookstore/frontend/src/App.tsx
+++ b/bookstore/frontend/src/App.tsx
@@ -12,81 +12,54 @@ import Cart from "./pages/Cart";
 import Order from "./pages/Order";
 import OrderList from "./pages/OrderList";
 
-const router = createBrowserRouter([
+const routeList = [
   {
     path: "/",
-    element: (
-      <Layout>
-        <Home />
-      </Layout>
-    ),
-    errorElement: <Error />,
+    element: <Home />,
   },
   {
     path: "/books",
-    element: (
-      <Layout>
-        <Books />
-      </Layout>
-    ),
+    element: <Books />,
   },
   {
     path: "/signup",
-    element: (
-      <Layout>
-        <Signup />
-      </Layout>
-    ),
+    element: <Signup />,
   },
   {
     path: "/reset",
-    element: (
-      <Layout>
-        <ResetPassword />
-      </Layout>
-    ),
+    element: <ResetPassword />,
   },
   {
     path: "/login",
-    element: (
-      <Layout>
-        <Login />
-      </Layout>
-    ),
+    element: <Login />,
   },
   {
     path: "/book/:bookId",
-    element: (
-      <Layout>
-        <BookDetail />
-      </Layout>
-    ),
+    element: <BookDetail />,
   },
   {
     path: "/cart",
-    element: (
-      <Layout>
-        <Cart />
-      </Layout>
-    ),
+    element: <Cart />,
   },
   {
     path: "/order",
-    element: (
-      <Layout>
-        <Order />
-      </Layout>
-    ),
+    element: <Order />,
   },
   {
     path: "/orderlist",
-    element: (
-      <Layout>
-        <OrderList />
-      </Layout>
-    ),
+    element: <OrderList />,
   },
-]);
+];
+
+const router = createBrowserRouter(
+  routeList.map((item) => {
+    return {
+      ...item,
+      element: <Layout>{item.element}</Layout>,
+      errorElement: <Error />,
+    };
+  }),
+);
 
 const App = () => {
   return (

--- a/bookstore/frontend/src/api/http.ts
+++ b/bookstore/frontend/src/api/http.ts
@@ -34,3 +34,30 @@ export const createClient = (config?: AxiosRequestConfig) => {
 };
 
 export const httpClient = createClient();
+
+type RequestMethod = "get" | "post" | "put" | "delete";
+
+export const requestHandler = async <T>(
+  method: RequestMethod,
+  url: string,
+  payload?: T,
+) => {
+  let response;
+
+  switch (method) {
+    case "post":
+      response = await httpClient.post(url, payload);
+      break;
+    case "get":
+      response = await httpClient.get(url);
+      break;
+    case "put":
+      response = await httpClient.put(url, payload);
+      break;
+    case "delete":
+      response = await httpClient.delete(url);
+      break;
+  }
+
+  return response.data;
+};

--- a/bookstore/frontend/src/api/queryClient.ts
+++ b/bookstore/frontend/src/api/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({});

--- a/bookstore/frontend/src/components/common/Loading.tsx
+++ b/bookstore/frontend/src/components/common/Loading.tsx
@@ -1,0 +1,30 @@
+import { FaSpinner } from "react-icons/fa";
+import styled from "styled-components";
+
+const Loading = () => {
+  return (
+    <LoadingStyle>
+      <FaSpinner />
+    </LoadingStyle>
+  );
+};
+
+const LoadingStyle = styled.div`
+  padding: 40px 0;
+  text-align: center;
+
+  @keyframes rotate {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  svg {
+    width: 70px;
+    height: 70px;
+    fill: #ccc;
+    animation: rotate 1s linear infinite;
+  }
+`;
+
+export default Loading;

--- a/bookstore/frontend/src/hooks/useAuth.ts
+++ b/bookstore/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,58 @@
+import { login, resetRequest, signup } from "@/api/auth.api";
+import { LoginProps } from "@/pages/Login";
+import { useAuthStore } from "@/store/authStore";
+import { useAlert } from "./useAlert";
+import { useNavigate } from "react-router-dom";
+import { SignupProps } from "@/pages/Signup";
+import { ResetPasswordProps } from "@/pages/ResetPassword";
+import { useState } from "react";
+
+export const useAuth = () => {
+  const navigate = useNavigate();
+  const { showAlert } = useAlert();
+  const { storeLogin } = useAuthStore();
+  const [resetRequested, setResetRequested] = useState(false);
+
+  const userLogin = (data: LoginProps) => {
+    login(data).then(
+      (res) => {
+        storeLogin(res.token);
+
+        showAlert("로그인이 완료되었습니다.");
+        navigate("/");
+      },
+      (error) => {
+        console.log(error);
+        showAlert("로그인이 실패했습니다.");
+      },
+    );
+  };
+
+  const userSignup = (data: SignupProps) => {
+    signup(data).then(() => {
+      showAlert("회원가입이 완료되었습니다.");
+      navigate("/login");
+    });
+  };
+
+  const userResetPassword = (data: ResetPasswordProps) => {
+    resetRequest(data).then(() => {
+      showAlert("비밀번호 초기화되었습니다.");
+      navigate("/login");
+    });
+  };
+
+  const userResetRequest = (data: ResetPasswordProps) => {
+    resetRequest(data).then(() => {
+      setResetRequested(true);
+    });
+  };
+
+  return {
+    userLogin,
+    userSignup,
+    userResetPassword,
+    userResetRequest,
+    resetRequested,
+  };
+};

--- a/bookstore/frontend/src/hooks/useBooks.ts
+++ b/bookstore/frontend/src/hooks/useBooks.ts
@@ -1,40 +1,32 @@
-import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Book } from "../models/book.model";
-import { Pagination } from "../models/pagination.model";
 import { LIMIT } from "../constants/pagination";
 import { fetchBooks } from "../api/books.api";
 import { QUERYSTRING } from "../constants/querystring";
+import { useQuery } from "@tanstack/react-query";
 
 export const useBooks = () => {
   const localtion = useLocation();
+  const params = new URLSearchParams(localtion.search);
 
-  const [books, setBooks] = useState<Book[]>([]);
-  const [pagination, setPagination] = useState<Pagination>({
-    totalCount: 0,
-    currentPage: 1,
+  const { data: booksData, isLoading: isBooksLoading } = useQuery({
+    queryKey: ["books", location.search],
+    queryFn: () =>
+      fetchBooks({
+        category_id: params.get(QUERYSTRING.CATEGORY_ID)
+          ? Number(params.get(QUERYSTRING.CATEGORY_ID))
+          : undefined,
+        news: params.get(QUERYSTRING.NEWS) ? true : undefined,
+        currentPage: params.get(QUERYSTRING.PAGE)
+          ? Number(params.get(QUERYSTRING.PAGE))
+          : 1,
+        limit: LIMIT,
+      }),
   });
 
-  const [isEmpty, setIsEmpty] = useState(true);
-
-  useEffect(() => {
-    const params = new URLSearchParams(localtion.search);
-
-    fetchBooks({
-      category_id: params.get(QUERYSTRING.CATEGORY_ID)
-        ? Number(params.get(QUERYSTRING.CATEGORY_ID))
-        : undefined,
-      news: params.get(QUERYSTRING.NEWS) ? true : undefined,
-      currentPage: params.get(QUERYSTRING.PAGE)
-        ? Number(params.get(QUERYSTRING.PAGE))
-        : 1,
-      limit: LIMIT,
-    }).then(({ books, pagination }) => {
-      setBooks(books);
-      setPagination(pagination);
-      setIsEmpty(books.length === 0);
-    });
-  }, [localtion.search]);
-
-  return { books, pagination, isEmpty };
+  return {
+    books: booksData?.books,
+    pagination: booksData?.pagination,
+    isEmpty: booksData?.books.length === 0,
+    isBooksLoading,
+  };
 };

--- a/bookstore/frontend/src/pages/Books.tsx
+++ b/bookstore/frontend/src/pages/Books.tsx
@@ -8,7 +8,7 @@ import { useBooks } from "../hooks/useBooks";
 import BooksViewSwitcher from "../components/books/BooksViewSwitcher";
 
 const Books = () => {
-  const { books, pagination, isEmpty } = useBooks();
+  const { books, pagination, isEmpty, isBooksLoading } = useBooks();
 
   return (
     <>
@@ -18,9 +18,9 @@ const Books = () => {
           <BooksFilter />
           <BooksViewSwitcher />
         </div>
-        {books.length > 0 && <BooksList books={books} />}
-        {books.length === 0 && <BooksEmpty />}
-        {!isEmpty && <Pagination pagination={pagination} />}
+        {!isEmpty && books && <BooksList books={books} />}
+        {!isEmpty && <BooksEmpty />}
+        {!isEmpty && pagination && <Pagination pagination={pagination} />}
       </BooksStyle>
     </>
   );

--- a/bookstore/frontend/src/pages/Books.tsx
+++ b/bookstore/frontend/src/pages/Books.tsx
@@ -6,9 +6,17 @@ import BooksFilter from "../components/books/BooksFilter";
 import Pagination from "../components/books/Pageination";
 import { useBooks } from "../hooks/useBooks";
 import BooksViewSwitcher from "../components/books/BooksViewSwitcher";
+import Loading from "@/components/common/Loading";
 
 const Books = () => {
   const { books, pagination, isEmpty, isBooksLoading } = useBooks();
+  if (isEmpty) {
+    return <BooksEmpty />;
+  }
+
+  if (!books || !pagination || !isBooksLoading) {
+    return <Loading />;
+  }
 
   return (
     <>
@@ -18,9 +26,8 @@ const Books = () => {
           <BooksFilter />
           <BooksViewSwitcher />
         </div>
-        {!isEmpty && books && <BooksList books={books} />}
-        {!isEmpty && <BooksEmpty />}
-        {!isEmpty && pagination && <Pagination pagination={pagination} />}
+        <BooksList books={books} />
+        <Pagination pagination={pagination} />
       </BooksStyle>
     </>
   );

--- a/bookstore/frontend/src/pages/Login.tsx
+++ b/bookstore/frontend/src/pages/Login.tsx
@@ -3,41 +3,25 @@ import styled from "styled-components";
 import Title from "../components/common/Title";
 import InputText from "../components/common/InputText";
 import Button from "../components/common/Button";
-import { Link, useNavigate } from "react-router-dom";
-import { login } from "../api/auth.api";
-import { useAlert } from "../hooks/useAlert";
-import { useAuthStore } from "../store/authStore";
+import { Link } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
 
-export interface SignupProps {
+export interface LoginProps {
   email: string;
   password: string;
 }
 
 const Login = () => {
-  const navigate = useNavigate();
-  const { showAlert } = useAlert();
-
-  const { storeLogin } = useAuthStore();
+  const { userLogin } = useAuth();
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<SignupProps>();
+  } = useForm<LoginProps>();
 
-  const onSubmit = (data: SignupProps) => {
-    login(data).then(
-      (res) => {
-        storeLogin(res.token);
-
-        showAlert("로그인이 완료되었습니다.");
-        navigate("/");
-      },
-      (error) => {
-        console.log(error);
-        showAlert("로그인이 실패했습니다.");
-      },
-    );
+  const onSubmit = (data: LoginProps) => {
+    userLogin(data);
   };
 
   return (

--- a/bookstore/frontend/src/pages/ResetPassword.tsx
+++ b/bookstore/frontend/src/pages/ResetPassword.tsx
@@ -3,10 +3,8 @@ import styled from "styled-components";
 import Title from "../components/common/Title";
 import InputText from "../components/common/InputText";
 import Button from "../components/common/Button";
-import { Link, useNavigate } from "react-router-dom";
-import { resetRequest } from "../api/auth.api";
-import { useAlert } from "../hooks/useAlert";
-import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
 
 export interface ResetPasswordProps {
   email: string;
@@ -14,9 +12,7 @@ export interface ResetPasswordProps {
 }
 
 const ResetPassword = () => {
-  const navigate = useNavigate();
-  const { showAlert } = useAlert();
-  const [resetRequested, setResetRequested] = useState(false);
+  const { userResetPassword, userResetRequest, resetRequested } = useAuth();
 
   const {
     register,
@@ -26,14 +22,9 @@ const ResetPassword = () => {
 
   const onSubmit = (data: ResetPasswordProps) => {
     if (resetRequested) {
-      resetRequest(data).then(() => {
-        showAlert("비밀번호 초기화되었습니다.");
-        navigate("/login");
-      });
+      userResetPassword(data);
     } else {
-      resetRequest(data).then(() => {
-        setResetRequested(true);
-      });
+      userResetRequest(data);
     }
   };
 

--- a/bookstore/frontend/src/pages/Signup.tsx
+++ b/bookstore/frontend/src/pages/Signup.tsx
@@ -3,9 +3,8 @@ import styled from "styled-components";
 import Title from "../components/common/Title";
 import InputText from "../components/common/InputText";
 import Button from "../components/common/Button";
-import { Link, useNavigate } from "react-router-dom";
-import { signup } from "../api/auth.api";
-import { useAlert } from "../hooks/useAlert";
+import { Link } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
 
 export interface SignupProps {
   email: string;
@@ -13,8 +12,7 @@ export interface SignupProps {
 }
 
 const Signup = () => {
-  const navigate = useNavigate();
-  const { showAlert } = useAlert();
+  const { userSignup } = useAuth();
 
   const {
     register,
@@ -23,10 +21,7 @@ const Signup = () => {
   } = useForm<SignupProps>();
 
   const onSubmit = (data: SignupProps) => {
-    signup(data).then(() => {
-      showAlert("회원가입이 완료되었습니다.");
-      navigate("/login");
-    });
+    userSignup(data);
   };
 
   return (

--- a/bookstore/frontend/tsconfig.app.json
+++ b/bookstore/frontend/tsconfig.app.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
@@ -7,7 +12,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -16,7 +20,6 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/bookstore/frontend/vite.config.ts
+++ b/bookstore/frontend/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
- 타입스크립트 경로 별칭 설정: 코드 가독성 향상을 위해 @/와 같은 별칭을 사용하여 프로젝트의 경로를 간단하게 참조할 수 있도록 설정했습니다.
- vite-tsconfig-paths 패키지 설치 및 활용: Vite가 타입스크립트 경로 별칭을 인식하도록 vite-tsconfig-paths 패키지를 추가했습니다.
- ESLint 설정 업데이트: 경로 별칭 관련 에러를 방지하기 위해 ESLint가 vite.config.ts 파일을 무시하도록 설정했습니다.